### PR TITLE
Add some desktop players

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -158,6 +158,13 @@ const List<String> musicApps = [
   'Zaycev.net',
   'Звук',
   'МТС Music',
+  'AIMP',
+  'MusicBee',
+  'foobar2000',
+  'Strawberry',
+  'Amarok',
+  'Winamp',
+  'WACUP'
 ];
 
 RegExp winRegExp = RegExp(


### PR DESCRIPTION
Added some local music players, but it would be cool if there would be an option to make custom `Listening to {sth}` or `Playing to {sth}`. Maybe I create a different issue about it

Players
- [AIMP](https://www.aimp.ru/) with integrated scrobbler
- [MusicBee](https://www.getmusicbee.com/), AFAIK with integrated too
- [foobar200](https://www.foobar2000.org) needs [plugin](https://github.com/gix/foo_scrobble)
- [Strawberry Music Player](https://www.strawberrymusicplayer.org/) with integrated scrobbler
- [Amarok](https://amarok.kde.org/) \([repo](https://invent.kde.org/multimedia/amarok)\) - has `Full Last.fm support`
- [Winamp](https://winamp.com/) and it's better version without NFTs and other trash [WACUP \(WinAmp Community Update Project\)](https://getwacup.com/). Can be used with ["Legacy Last.fm Desktop App"](https://www.last.fm/about/trackmymusic)